### PR TITLE
Dev/dani add bank information to agent answers

### DIFF
--- a/src/firebase/providers.js
+++ b/src/firebase/providers.js
@@ -39,6 +39,21 @@ export const createProvider = async (providerData) => {
   });
 };
 
+// Obtener proveedor del cliente o retornar uno por defecto
+export const getClientProvider = async (providerId) => {
+  // Si no hay providerId, retornar el proveedor por defecto (Acriventas)
+  if (!providerId) return await getProviderById("39gNkqv2h1P9O1FLBjLf");
+  const providerRef = doc(db, "providers", providerId);
+  const providerDoc = await getDoc(providerRef);
+
+  if (!providerDoc.exists()) {
+    // Si no existe, retornar el proveedor por defecto (Acriventas)
+    return await getProviderById("39gNkqv2h1P9O1FLBjLf");
+  }
+
+  return { id: providerDoc.id, ...providerDoc.data() };
+}
+
 // Obtener un proveedor por ID
 export const getProviderById = async (providerId) => {
   if (!providerId) return null;

--- a/src/pages/ConversationDetail.jsx
+++ b/src/pages/ConversationDetail.jsx
@@ -751,6 +751,7 @@ const ConversationDetail = () => {
                         <option value="thanks">Agradece</option>
                         <option value="no_answer">No contesta</option>
                         <option value="confirms_payment">Confirma pago</option>
+                        <option value="asks_bank_info">Solicita información bancaria</option>
                       </select>
                     </div>
                   </div>

--- a/src/pages/ConversationDetail.jsx
+++ b/src/pages/ConversationDetail.jsx
@@ -634,7 +634,7 @@ const ConversationDetail = () => {
                             />
                           ) : (
                             <>
-                              <p>{turn.message}</p>
+                              <p className="whitespace-pre-line">{turn.message}</p>
                               <div className="text-xs text-gray-500 mt-1 flex justify-between">
                                 <span>{formatDate(turn.timestamp)}</span>
                                 {turn.isManual && <span className="text-blue-500">Manual</span>}

--- a/src/pages/NewConversation.jsx
+++ b/src/pages/NewConversation.jsx
@@ -570,7 +570,7 @@ const NewConversation = () => {
                                 : 'bg-gray-100 text-gray-800'
                             }`}
                           >
-                            <p>{turn.message}</p>
+                            <p className="whitespace-pre-line">{turn.message}</p>
                             <p className="text-xs text-gray-500 mt-1">
                               {turn.timestamp.toLocaleTimeString()}
                             </p>

--- a/src/pages/NewConversation.jsx
+++ b/src/pages/NewConversation.jsx
@@ -323,7 +323,8 @@ const NewConversation = () => {
       'refuses': { relationship: -20, history: -20, attitude: -20, sensitivity: 20, probability: -30 },
       'thanks': { relationship: 5, history: 0, attitude: 10, sensitivity: -5, probability: 10 },
       'no_answer': { relationship: -5, history: -10, attitude: -5, sensitivity: 0, probability: -10 },
-      'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 }
+      'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 },
+      'asks_bank_info': { relationship: 8, history: 5, attitude: 15, sensitivity: -5, probability: 25 }
     };
     
     setSuggestedDeltas(EVENT_DELTAS[newEventType] || EVENT_DELTAS.neutral);
@@ -682,6 +683,7 @@ const NewConversation = () => {
                     <option value="thanks">Agradece recordatorio</option>
                     <option value="no_answer">No contesta la llamada</option>
                     <option value="confirms_payment">Confirma pago realizado</option>
+                    <option value="asks_bank_info">Solicita información bancaria</option>
                   </select>
                 </div>
                 

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -595,9 +595,9 @@ const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClie
     },
     'asks_bank_info': {
       friendly_no_pressure: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le enviaré la información bancaria por separado.'}`,
-      friendly: `Don/Doña ${clientInfo?.name || ''}, me le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le enviaré la información bancaria completa.'}`,
+      friendly: `Don/Doña ${clientInfo?.name || ''}, le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le enviaré la información bancaria completa.'}`,
       formal_direct: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Recibirá la información bancaria detallada.'}`,
-      formal_soft: `Don/Doña ${clientInfo?.name || ''}, me le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le haré llegar todos los datos bancarios necesarios.'}`,
+      formal_soft: `Don/Doña ${clientInfo?.name || ''}, le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le haré llegar todos los datos bancarios necesarios.'}`,
       neutral: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le proporcionaré la información bancaria completa.'}`
     },
     'default': {

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -334,7 +334,7 @@ export const generateAgentResponse = async (conversationHistory, clientSoul, las
     if (!API_KEY || API_KEY.trim() === "") {
       const clientInfo = await getClientById(clientId);
       const providerInfo = await getClientProvider(clientInfo?.provider_id);
-      return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo);
+      return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo, clientInfo);
     }
     
     const API_URL = "https://api.openai.com/v1/chat/completions";
@@ -452,7 +452,7 @@ Genere UNA respuesta concisa (máximo 2 oraciones) usando tratamiento formal y d
     };
   } catch (error) {
     console.error('Error al generar respuesta con OpenAI:', error);
-    return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, context.providerInfo);
+    return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, context.providerInfo, context.clientInfo);
   }
 };
 
@@ -517,7 +517,7 @@ const fallbackAnalyzeClientMessage = (message, conversationHistory, clientSoul) 
 };
 
 // Modificado para recibir providerInfo
-const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo = null) => {
+const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo = null, clientInfo = null) => {
 
   let tone = 'neutral';
   
@@ -594,11 +594,11 @@ const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClie
       neutral: "Gracias por informarnos. Verificaremos el pago y actualizaremos el estado de su cuenta."
     },
     'asks_bank_info': {
-      friendly_no_pressure: `Por supuesto, con mucho gusto le proporciono los datos. ${providerInfo?.bank_information || 'Le enviaré la información bancaria por separado.'}`,
-      friendly: `Claro que sí, aquí tiene los datos bancarios: ${providerInfo?.bank_information || 'Le enviaré la información bancaria completa.'}`,
-      formal_direct: `Le proporciono los datos bancarios para realizar el pago: ${providerInfo?.bank_information || 'Recibirá la información bancaria detallada.'}`,
-      formal_soft: `Con gusto le facilito la información de pago: ${providerInfo?.bank_information || 'Le haré llegar todos los datos bancarios necesarios.'}`,
-      neutral: `Aquí están los datos para realizar el pago: ${providerInfo?.bank_information || 'Le proporcionaré la información bancaria completa.'}`
+      friendly_no_pressure: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le enviaré la información bancaria por separado.'}`,
+      friendly: `Don/Doña ${clientInfo?.name || ''}, me le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le enviaré la información bancaria completa.'}`,
+      formal_direct: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Recibirá la información bancaria detallada.'}`,
+      formal_soft: `Don/Doña ${clientInfo?.name || ''}, me le adjunto las cuentas de ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le haré llegar todos los datos bancarios necesarios.'}`,
+      neutral: `Señor@ ${clientInfo?.name || ''}, esta es la información de las cuentas bancarias para ${providerInfo?.name || 'nuestra empresa'}: ${providerInfo?.bank_information || 'Le proporcionaré la información bancaria completa.'}`
     },
     'default': {
       friendly_no_pressure: "Entiendo perfectamente su situación. No se preocupe, cuando pueda realizar el pago solo avíseme.",

--- a/src/services/openaiService.js
+++ b/src/services/openaiService.js
@@ -2,6 +2,7 @@
 import axios from 'axios';
 import { getConversationsByClient, getClosedConversations } from '../firebase/conversations';
 import { getAllClients, getClientById } from '../firebase/clients';
+import { getClientProvider } from '../firebase/providers';
 
 // Función para obtener la API key de localStorage
 const getApiKey = () => localStorage.getItem('openai_api_key') || "";
@@ -153,6 +154,8 @@ const buildContextualPrompt = async (clientId, clientSoul, conversationHistory, 
     console.error('Error obteniendo información del cliente:', error);
   }
 
+  const providerInfo = await getClientProvider(clientInfo?.provider_id);
+
   const previousContext = await getPreviousConversationContext(clientId);
   const similarContext = previousContext ? null : await getSimilarClientContext(clientSoul, clientInfo?.debt || 0);
   
@@ -195,7 +198,8 @@ const buildContextualPrompt = async (clientId, clientSoul, conversationHistory, 
     currentConversation,
     currentPhase,
     phaseDescription: phaseDescription[currentPhase] || phaseDescription.negotiation,
-    clientInfo
+    clientInfo,
+    providerInfo
   };
 };
 
@@ -257,6 +261,7 @@ Analiza el siguiente mensaje del cliente y clasifícalo en UNA de estas categor�
 - thanks
 - no_answer
 - confirms_payment
+- asks_bank_info
 
 Responde SOLO con la categoría, sin explicaciones adicionales.`;
 
@@ -283,7 +288,7 @@ Responde SOLO con la categoría, sin explicaciones adicionales.`;
     let eventType = 'neutral';
     const possibleEvents = [
       'neutral', 'accepts_payment', 'offers_partial', 'reschedule', 
-      'evades', 'annoyed', 'refuses', 'thanks', 'no_answer', 'confirms_payment'
+      'evades', 'annoyed', 'refuses', 'thanks', 'no_answer', 'confirms_payment', 'asks_bank_info'
     ];
     
     for (const event of possibleEvents) {
@@ -303,7 +308,8 @@ Responde SOLO con la categoría, sin explicaciones adicionales.`;
       'refuses': { relationship: -20, history: -20, attitude: -20, sensitivity: 20, probability: -30 },
       'thanks': { relationship: 5, history: 0, attitude: 10, sensitivity: -5, probability: 10 },
       'no_answer': { relationship: -5, history: -10, attitude: -5, sensitivity: 0, probability: -10 },
-      'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 }
+      'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 },
+      'asks_bank_info': { relationship: 8, history: 5, attitude: 15, sensitivity: -5, probability: 25 }
     };
 
     const deltas = deltaMap[eventType] || deltaMap.neutral;
@@ -326,7 +332,9 @@ export const generateAgentResponse = async (conversationHistory, clientSoul, las
     const API_KEY = getApiKey();
     
     if (!API_KEY || API_KEY.trim() === "") {
-      return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent);
+      const clientInfo = await getClientById(clientId);
+      const providerInfo = await getClientProvider(clientInfo?.provider_id);
+      return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo);
     }
     
     const API_URL = "https://api.openai.com/v1/chat/completions";
@@ -367,7 +375,8 @@ export const generateAgentResponse = async (conversationHistory, clientSoul, las
       ? `\nINFORMACIÓN DE DEUDA: $${context.clientInfo.debt.toLocaleString('es-CO')} COP`
       : '';
     
-    const systemPrompt = `Eres un agente de cobranza profesional de Acriventas. Tu objetivo es recuperar pagos pendientes manteniendo buenas relaciones con los clientes.
+    // Modificado para usar el nombre del proveedor del cliente
+    const systemPrompt = `Eres un agente de cobranza profesional de ${context.providerInfo.name}. Tu objetivo es recuperar pagos pendientes manteniendo buenas relaciones con los clientes.
 
 REGLAS FUNDAMENTALES DE COMUNICACIÓN:
 1. SIEMPRE usar tratamiento formal (usted, nunca tutear)
@@ -375,6 +384,13 @@ REGLAS FUNDAMENTALES DE COMUNICACIÓN:
 3. En FASE DE COMUNICACIÓN DE DEUDA: Si el cliente pregunta por el monto, proporcionar la cifra específica
 4. Mantener tono profesional, empático y orientado a soluciones
 5. Adaptar el tono al perfil del cliente
+6. Si el cliente pregunta por los datos bancarios, proporcionar la información bancaria
+
+${lastEvent === "asks_bank_info" ? `
+  INFORMACIÓN BANCARIA:
+  ${context.providerInfo.bank_information}
+  `: ""
+}
 
 ${context.contextSection}
 
@@ -436,7 +452,7 @@ Genere UNA respuesta concisa (máximo 2 oraciones) usando tratamiento formal y d
     };
   } catch (error) {
     console.error('Error al generar respuesta con OpenAI:', error);
-    return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent);
+    return fallbackGenerateAgentResponse(conversationHistory, clientSoul, lastClientMessage, lastEvent, context.providerInfo);
   }
 };
 
@@ -446,7 +462,15 @@ const fallbackAnalyzeClientMessage = (message, conversationHistory, clientSoul) 
   
   let eventType = 'neutral';
   
-  if (messageText.includes('pagar') || messageText.includes('transferir') || messageText.includes('depositar')) {
+  if (messageText.includes('datos bancarios') || messageText.includes('información bancaria') || 
+      messageText.includes('número de cuenta') || messageText.includes('cuenta bancaria') ||
+      (messageText.includes('banco') && (messageText.includes('cuál') || messageText.includes('cual') || messageText.includes('dónde') || messageText.includes('donde'))) ||
+      (messageText.includes('cuenta') && (messageText.includes('cuál') || messageText.includes('cual') || messageText.includes('número'))) ||
+      (messageText.includes('transferir') && (messageText.includes('dónde') || messageText.includes('donde') || messageText.includes('cuál') || messageText.includes('cual'))) ||
+      (messageText.includes('pagar') && (messageText.includes('dónde') || messageText.includes('donde') || messageText.includes('cuál') || messageText.includes('cual'))) ||
+      messageText.includes('datos para pagar') || messageText.includes('información para pagar')) {
+    eventType = 'asks_bank_info';
+  } else if (messageText.includes('pagar') || messageText.includes('transferir') || messageText.includes('depositar')) {
     if (messageText.includes('completo') || messageText.includes('todo') || messageText.includes('total')) {
       eventType = 'accepts_payment';
     } else if (messageText.includes('parte') || messageText.includes('parcial') || messageText.includes('algo') || messageText.includes('abono')) {
@@ -478,7 +502,8 @@ const fallbackAnalyzeClientMessage = (message, conversationHistory, clientSoul) 
     'refuses': { relationship: -20, history: -20, attitude: -20, sensitivity: 20, probability: -30 },
     'thanks': { relationship: 5, history: 0, attitude: 10, sensitivity: -5, probability: 10 },
     'no_answer': { relationship: -5, history: -10, attitude: -5, sensitivity: 0, probability: -10 },
-    'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 }
+    'confirms_payment': { relationship: 10, history: 20, attitude: 20, sensitivity: -10, probability: 30 },
+    'asks_bank_info': { relationship: 8, history: 5, attitude: 15, sensitivity: -5, probability: 25 }
   };
   
   const deltas = deltaMap[eventType] || deltaMap.neutral;
@@ -491,7 +516,9 @@ const fallbackAnalyzeClientMessage = (message, conversationHistory, clientSoul) 
   };
 };
 
-const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClientMessage, lastEvent) => {
+// Modificado para recibir providerInfo
+const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClientMessage, lastEvent, providerInfo = null) => {
+
   let tone = 'neutral';
   
   if (clientSoul.relationship > 70) {
@@ -565,6 +592,13 @@ const fallbackGenerateAgentResponse = (conversationHistory, clientSoul, lastClie
       formal_direct: "Gracias por su confirmación. Procederemos a verificar el pago y le notificaremos una vez esté procesado en el sistema.",
       formal_soft: "Agradecemos mucho su pago. Realizaremos la verificación correspondiente y le informaremos cuando esté todo listo.",
       neutral: "Gracias por informarnos. Verificaremos el pago y actualizaremos el estado de su cuenta."
+    },
+    'asks_bank_info': {
+      friendly_no_pressure: `Por supuesto, con mucho gusto le proporciono los datos. ${providerInfo?.bank_information || 'Le enviaré la información bancaria por separado.'}`,
+      friendly: `Claro que sí, aquí tiene los datos bancarios: ${providerInfo?.bank_information || 'Le enviaré la información bancaria completa.'}`,
+      formal_direct: `Le proporciono los datos bancarios para realizar el pago: ${providerInfo?.bank_information || 'Recibirá la información bancaria detallada.'}`,
+      formal_soft: `Con gusto le facilito la información de pago: ${providerInfo?.bank_information || 'Le haré llegar todos los datos bancarios necesarios.'}`,
+      neutral: `Aquí están los datos para realizar el pago: ${providerInfo?.bank_information || 'Le proporcionaré la información bancaria completa.'}`
     },
     'default': {
       friendly_no_pressure: "Entiendo perfectamente su situación. No se preocupe, cuando pueda realizar el pago solo avíseme.",


### PR DESCRIPTION
# 🏦 Add Bank Information Support to Agent Responses

## Overview
Enhanced the OpenAI service to detect when clients request bank information and automatically provide payment details in agent responses.

## Key Changes

### 🆕 New Event Detection: `asks_bank_info`
- Added detection for phrases like "datos bancarios", "información bancaria", "número de cuenta"
- Includes contextual patterns: "¿cuál es el banco?", "¿dónde pago?"
- Positive impact on client metrics:
  - **Relationship**: +8 (shows willingness to engage)
  - **Attitude**: +15 (positive intent to pay)
  - **Probability**: +25 (high likelihood of payment)

### 🤖 Enhanced Agent Responses
- **OpenAI Integration**: Automatically includes bank information when `asks_bank_info` event is detected
- **Fallback System**: Added response templates for all communication tones:
  - Friendly (no pressure/regular)
  - Formal (direct/soft)
  - Neutral
- **Dynamic Content**: Uses `providerInfo.bank_information` to provide actual payment details

### 📋 Example Responses
**Client**: "¿Cuáles son los datos bancarios para pagar?"

**Agent Response**: "Con gusto le facilito la información de pago: [BANK_INFORMATION_HERE]"

## Files Modified
- `src/firebase/providers.js` - Function to retrieve a provider information with a default value
- `src/services/openaiService.js` - Core functionality updates 
- `src/pages/ConversationDetail.jsx` - Update events to recognize `asks_bank_info`
- `src/pages/NewConversation.jsx` - Update events to recognize `asks_bank_info`
